### PR TITLE
support for x-www-form-urlencoded in access_tokens, refresh_tokens, revoke_tokens

### DIFF
--- a/lib/zoom/actions.rb
+++ b/lib/zoom/actions.rb
@@ -2,6 +2,8 @@
 
 module Zoom
   module Actions
+    FORM_URLENCODED_HEADER = { 'Content-Type' => 'application/x-www-form-urlencoded' }.freeze
+
     def self.extract_path_keys(path)
       path.scan(/:\w+/).map { |match| match[1..].to_sym }
     end
@@ -15,7 +17,9 @@ module Zoom
       parsed_path
     end
 
-    def self.make_request(client, method, parsed_path, params, base_uri, headers = nil)
+    def self.make_request(args)
+      client, method, parsed_path, params, base_uri, headers =
+        args.values_at :client, :method, :parsed_path, :params, :base_uri, :headers
       request_options = { headers: client.request_headers.merge(headers || {}) }
       request_options[:base_uri] = base_uri if base_uri
       case method
@@ -43,7 +47,10 @@ module Zoom
           params = params.require(path_keys) unless path_keys.empty?
           params_without_required = required.empty? ? params : params.require(required)
           params_without_required.permit(permitted) unless permitted.empty?
-          response = Zoom::Actions.make_request(self, method, parsed_path, params, base_uri, headers)
+          response = Zoom::Actions.make_request({
+            client: self,  method: method,  parsed_path: parsed_path,
+            params: params, base_uri: base_uri,  headers: headers
+          })
           Utils.parse_response(response)
         end
       end

--- a/lib/zoom/actions.rb
+++ b/lib/zoom/actions.rb
@@ -16,7 +16,7 @@ module Zoom
     end
 
     def self.make_request(client, method, parsed_path, params, base_uri, url_encoded: false)
-      request_options = { headers: url_encoded ? client.url_encoded_request_headers : client.request_headers }
+      request_options = { headers: url_encoded ? client.form_url_encoded_request_headers : client.request_headers }
       request_options[:base_uri] = base_uri if base_uri
       case method
       when :get

--- a/lib/zoom/actions.rb
+++ b/lib/zoom/actions.rb
@@ -41,13 +41,13 @@ module Zoom
           params_without_required = required.empty? ? params : params.require(required)
           params_without_required.permit(permitted) unless permitted.empty?
           response = Zoom::Actions.make_request(self, method, parsed_path, params, base_uri,
-                                                url_encoded: Zoom::Actions.url_encoded_actions.include?(name))
+                                                url_encoded: Zoom::Actions.form_url_encoded_actions.include?(name))
           Utils.parse_response(response)
         end
       end
     end
 
-    def self.url_encoded_actions
+    def self.form_url_encoded_actions
       %w[access_tokens refresh_tokens revoke_tokens]
     end
   end

--- a/lib/zoom/actions.rb
+++ b/lib/zoom/actions.rb
@@ -15,8 +15,8 @@ module Zoom
       parsed_path
     end
 
-    def self.make_request(client, method, parsed_path, params, base_uri)
-      request_options = { headers: client.request_headers }
+    def self.make_request(client, method, parsed_path, params, base_uri, url_encoded: false)
+      request_options = { headers: url_encoded ? client.url_encoded_request_headers : client.request_headers }
       request_options[:base_uri] = base_uri if base_uri
       case method
       when :get
@@ -40,10 +40,15 @@ module Zoom
           params = params.require(path_keys) unless path_keys.empty?
           params_without_required = required.empty? ? params : params.require(required)
           params_without_required.permit(permitted) unless permitted.empty?
-          response = Zoom::Actions.make_request(self, method, parsed_path, params, base_uri)
+          response = Zoom::Actions.make_request(self, method, parsed_path, params, base_uri,
+                                                url_encoded: Zoom::Actions.url_encoded_actions.include?(name))
           Utils.parse_response(response)
         end
       end
+    end
+
+    def self.url_encoded_actions
+      %w[access_tokens refresh_tokens revoke_tokens]
     end
   end
 end

--- a/lib/zoom/actions.rb
+++ b/lib/zoom/actions.rb
@@ -35,20 +35,18 @@ module Zoom
 
         define_method(name) do |*args|
           path_keys = Zoom::Actions.extract_path_keys(path)
-          params = Zoom::Params.new(Utils.extract_options!(args))
+          params = Utils.extract_options!(args)
+          params = Zoom::Actions::Token.convert_param_names!(params)
+          params = Zoom::Params.new(params)
           parsed_path = Zoom::Actions.parse_path(path, path_keys, params)
           params = params.require(path_keys) unless path_keys.empty?
           params_without_required = required.empty? ? params : params.require(required)
           params_without_required.permit(permitted) unless permitted.empty?
           response = Zoom::Actions.make_request(self, method, parsed_path, params, base_uri,
-                                                url_encoded: Zoom::Actions.form_url_encoded_actions.include?(name))
+                                                url_encoded: Zoom::Actions::Token.form_url_encoded_actions.include?(name))
           Utils.parse_response(response)
         end
       end
-    end
-
-    def self.form_url_encoded_actions
-      %w[access_tokens refresh_tokens revoke_tokens]
     end
   end
 end

--- a/lib/zoom/actions/token.rb
+++ b/lib/zoom/actions/token.rb
@@ -6,12 +6,14 @@ module Zoom
       extend Zoom::Actions
 
       post 'access_tokens',
-        '/oauth/token?grant_type=authorization_code&code=:auth_code&redirect_uri=:redirect_uri',
-        base_uri: 'https://zoom.us/'
+        '/oauth/token?grant_type=authorization_code',
+        base_uri: 'https://zoom.us/',
+        require: %i[code redirect_uri]
 
       post 'refresh_tokens',
-        '/oauth/token?grant_type=refresh_token&refresh_token=:refresh_token',
-        base_uri: 'https://zoom.us/'
+        '/oauth/token?grant_type=refresh_token',
+        base_uri: 'https://zoom.us/',
+        require: :refresh_token
 
       post 'data_compliance', '/oauth/data/compliance',
         base_uri: 'https://zoom.us/',
@@ -19,8 +21,9 @@ module Zoom
           client_id user_id account_id deauthorization_event_received compliance_completed
         ]
 
-      post 'revoke_tokens', '/oauth/revoke?token=:access_token',
-        base_uri: 'https://zoom.us/'
+      post 'revoke_tokens', '/oauth/revoke',
+        base_uri: 'https://zoom.us/',
+        require: :token
     end
   end
 end

--- a/lib/zoom/actions/token.rb
+++ b/lib/zoom/actions/token.rb
@@ -8,12 +8,15 @@ module Zoom
       post 'access_tokens',
         '/oauth/token?grant_type=authorization_code',
         base_uri: 'https://zoom.us/',
-        require: %i[code redirect_uri]
+        require: %i[code redirect_uri],
+        args_to_params: { auth_code: :code },
+        headers: { 'Content-Type' => 'application/x-www-form-urlencoded' }
 
       post 'refresh_tokens',
         '/oauth/token?grant_type=refresh_token',
         base_uri: 'https://zoom.us/',
-        require: :refresh_token
+        require: :refresh_token,
+        headers: { 'Content-Type' => 'application/x-www-form-urlencoded' }
 
       post 'data_compliance', '/oauth/data/compliance',
         base_uri: 'https://zoom.us/',
@@ -23,17 +26,9 @@ module Zoom
 
       post 'revoke_tokens', '/oauth/revoke',
         base_uri: 'https://zoom.us/',
-        require: :token
-
-      def self.convert_param_names!(params)
-        params[:code] = params.delete :auth_code if params[:auth_code]
-        params[:token] = params.delete :access_token if params[:access_token]
-        params
-      end
-
-      def self.form_url_encoded_actions
-        %w[access_tokens refresh_tokens revoke_tokens]
-      end
+        require: :token,
+        args_to_params: { access_token: :token },
+        headers: { 'Content-Type' => 'application/x-www-form-urlencoded' }
     end
   end
 end

--- a/lib/zoom/actions/token.rb
+++ b/lib/zoom/actions/token.rb
@@ -24,6 +24,16 @@ module Zoom
       post 'revoke_tokens', '/oauth/revoke',
         base_uri: 'https://zoom.us/',
         require: :token
+
+      def self.convert_param_names!(params)
+        params[:code] = params.delete :auth_code if params[:auth_code]
+        params[:token] = params.delete :access_token if params[:access_token]
+        params
+      end
+
+      def self.form_url_encoded_actions
+        %w[access_tokens refresh_tokens revoke_tokens]
+      end
     end
   end
 end

--- a/lib/zoom/actions/token.rb
+++ b/lib/zoom/actions/token.rb
@@ -10,13 +10,13 @@ module Zoom
         base_uri: 'https://zoom.us/',
         require: %i[code redirect_uri],
         args_to_params: { auth_code: :code },
-        headers: { 'Content-Type' => 'application/x-www-form-urlencoded' }
+        headers: FORM_URLENCODED_HEADER
 
       post 'refresh_tokens',
         '/oauth/token?grant_type=refresh_token',
         base_uri: 'https://zoom.us/',
         require: :refresh_token,
-        headers: { 'Content-Type' => 'application/x-www-form-urlencoded' }
+        headers: FORM_URLENCODED_HEADER
 
       post 'data_compliance', '/oauth/data/compliance',
         base_uri: 'https://zoom.us/',
@@ -28,7 +28,7 @@ module Zoom
         base_uri: 'https://zoom.us/',
         require: :token,
         args_to_params: { access_token: :token },
-        headers: { 'Content-Type' => 'application/x-www-form-urlencoded' }
+        headers: FORM_URLENCODED_HEADER
     end
   end
 end

--- a/lib/zoom/client.rb
+++ b/lib/zoom/client.rb
@@ -29,12 +29,12 @@ module Zoom
     def headers
       {
         'Accept' => 'application/json',
-        'Content-Type' => 'application/json'
+        'Content-Type' => 'application/json',
       }
     end
 
     def form_url_encoded_headers
-      headers.merge({ 'Content-Type' => 'application/x-www-form-urlencoded' })
+      headers.merge('Content-Type' => 'application/x-www-form-urlencoded')
     end
 
     def oauth_request_headers

--- a/lib/zoom/client.rb
+++ b/lib/zoom/client.rb
@@ -33,7 +33,7 @@ module Zoom
       }
     end
 
-    def x_www_form_url_encoded_headers
+    def form_url_encoded_headers
       headers.merge({ 'Content-Type' => 'application/x-www-form-urlencoded' })
     end
 
@@ -54,7 +54,7 @@ module Zoom
     end
 
     def url_encoded_request_headers
-      bearer_authorization_header.merge(x_www_form_url_encoded_headers)
+      bearer_authorization_header.merge(form_url_encoded_headers)
     end
 
     def auth_token

--- a/lib/zoom/client.rb
+++ b/lib/zoom/client.rb
@@ -53,7 +53,7 @@ module Zoom
       bearer_authorization_header.merge(headers)
     end
 
-    def url_encoded_request_headers
+    def form_url_encoded_request_headers
       bearer_authorization_header.merge(form_url_encoded_headers)
     end
 

--- a/lib/zoom/client.rb
+++ b/lib/zoom/client.rb
@@ -33,10 +33,6 @@ module Zoom
       }
     end
 
-    def form_url_encoded_headers
-      headers.merge('Content-Type' => 'application/x-www-form-urlencoded')
-    end
-
     def oauth_request_headers
       {
         'Authorization' => "Basic #{auth_token}"
@@ -51,10 +47,6 @@ module Zoom
 
     def request_headers
       bearer_authorization_header.merge(headers)
-    end
-
-    def form_url_encoded_request_headers
-      bearer_authorization_header.merge(form_url_encoded_headers)
     end
 
     def auth_token

--- a/lib/zoom/client.rb
+++ b/lib/zoom/client.rb
@@ -29,8 +29,12 @@ module Zoom
     def headers
       {
         'Accept' => 'application/json',
-        'Content-Type' => 'application/json',
+        'Content-Type' => 'application/json'
       }
+    end
+
+    def x_www_form_url_encoded_headers
+      headers.merge({ 'Content-Type' => 'application/x-www-form-urlencoded' })
     end
 
     def oauth_request_headers
@@ -39,10 +43,18 @@ module Zoom
       }.merge(headers)
     end
 
-    def request_headers
+    def bearer_authorization_header
       {
         'Authorization' => "Bearer #{access_token}"
-      }.merge(headers)
+      }
+    end
+
+    def request_headers
+      bearer_authorization_header.merge(headers)
+    end
+
+    def url_encoded_request_headers
+      bearer_authorization_header.merge(x_www_form_url_encoded_headers)
     end
 
     def auth_token

--- a/lib/zoom/utils.rb
+++ b/lib/zoom/utils.rb
@@ -39,7 +39,7 @@ module Zoom
 
       def convert_param_names!(params)
         params[:code] = params.delete :auth_code if params[:auth_code]
-        params[:token] = params.delete :auth_code if params[:access_token]
+        params[:token] = params.delete :access_token if params[:access_token]
         params
       end
 

--- a/lib/zoom/utils.rb
+++ b/lib/zoom/utils.rb
@@ -34,6 +34,13 @@ module Zoom
       def extract_options!(array)
         params = array.last.is_a?(::Hash) ? array.pop : {}
         process_datetime_params!(params)
+        convert_param_names!(params)
+      end
+
+      def convert_param_names!(params)
+        params[:code] = params.delete :auth_code if params[:auth_code]
+        params[:token] = params.delete :auth_code if params[:access_token]
+        params
       end
 
       def validate_password(password)

--- a/lib/zoom/utils.rb
+++ b/lib/zoom/utils.rb
@@ -34,13 +34,6 @@ module Zoom
       def extract_options!(array)
         params = array.last.is_a?(::Hash) ? array.pop : {}
         process_datetime_params!(params)
-        convert_param_names!(params)
-      end
-
-      def convert_param_names!(params)
-        params[:code] = params.delete :auth_code if params[:auth_code]
-        params[:token] = params.delete :access_token if params[:access_token]
-        params
       end
 
       def validate_password(password)

--- a/spec/fixtures/token/revoke_token.json
+++ b/spec/fixtures/token/revoke_token.json
@@ -1,0 +1,3 @@
+{
+  "status": "success"
+}

--- a/spec/lib/zoom/actions/token/access_token_spec.rb
+++ b/spec/lib/zoom/actions/token/access_token_spec.rb
@@ -16,7 +16,7 @@ describe Zoom::Actions::Token do
     end
 
     it "requires an error when args missing" do
-      expect { zc.access_tokens }.to raise_error(Zoom::ParameterMissing, [:auth_code, :redirect_uri].to_s)
+      expect { zc.access_tokens }.to raise_error(Zoom::ParameterMissing, [:code, :redirect_uri].to_s)
     end
 
     it 'returns a hash' do

--- a/spec/lib/zoom/actions/token/access_token_spec.rb
+++ b/spec/lib/zoom/actions/token/access_token_spec.rb
@@ -15,12 +15,25 @@ describe Zoom::Actions::Token do
                     headers: { 'Content-Type' => 'application/json' })
     end
 
-    it "requires an error when args missing" do
+    it "raises an error when args missing" do
       expect { zc.access_tokens }.to raise_error(Zoom::ParameterMissing, [:code, :redirect_uri].to_s)
     end
 
     it 'returns a hash' do
       expect(zc.access_tokens(args)).to be_kind_of(Hash)
+    end
+
+    it 'passes args in the body' do
+      # allow(Zoom::Actions).to receive(:post).with(
+      #   '/oauth/token?grant_type=authorization_code',
+      #   { code: 'xxx', redirect_uri: 'http://localhost:3000' }
+      # )
+      # zc.access_tokens(args)
+      expect(Zoom::Actions).to receive(:post).with(
+        '/oauth/token?grant_type=authorization_code',
+        { body: { code: 'xxx', redirect_uri: 'http://localhost:3000' } }
+      )
+      zc.access_tokens(args)
     end
   end
 end

--- a/spec/lib/zoom/actions/token/data_compliance_spec.rb
+++ b/spec/lib/zoom/actions/token/data_compliance_spec.rb
@@ -30,7 +30,7 @@ describe Zoom::Actions::Token do
                     headers: { 'Content-Type' => 'application/json' })
     end
 
-    it "requires an error when args missing" do
+    it "raises an error when args missing" do
       expect { zc.data_compliance }.to raise_error(Zoom::ParameterMissing, [:client_id, :user_id, :account_id, :deauthorization_event_received, :compliance_completed].to_s)
     end
 

--- a/spec/lib/zoom/actions/token/refresh_token_spec.rb
+++ b/spec/lib/zoom/actions/token/refresh_token_spec.rb
@@ -15,7 +15,7 @@ describe Zoom::Actions::Token do
                     headers: { 'Content-Type' => 'application/json' })
     end
 
-    it "requires an error when args missing" do
+    it "raises an error when args missing" do
       expect { zc.refresh_tokens }.to raise_error(Zoom::ParameterMissing, [:refresh_token].to_s)
     end
 

--- a/spec/lib/zoom/actions/token/revoke_token_spec.rb
+++ b/spec/lib/zoom/actions/token/revoke_token_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Zoom::Actions::Token do
+  let(:zc) { oauth_client }
+  let(:args) { { access_token: 'xxx' } }
+
+  describe '#revoke_tokens action' do
+    before :each do
+      stub_request(
+        :post,
+        zoom_auth_url('oauth/revoke')
+      ).to_return(body: json_response('token', 'revoke_token'),
+                    headers: { 'Content-Type' => 'application/json' })
+    end
+
+    it "requires an error when args missing" do
+      expect { zc.revoke_tokens }.to raise_error(Zoom::ParameterMissing, [:token].to_s)
+    end
+
+    it 'returns a hash' do
+      expect(zc.revoke_tokens(args)).to be_kind_of(Hash)
+    end
+  end
+end

--- a/spec/lib/zoom/actions/token/revoke_token_spec.rb
+++ b/spec/lib/zoom/actions/token/revoke_token_spec.rb
@@ -15,7 +15,7 @@ describe Zoom::Actions::Token do
                     headers: { 'Content-Type' => 'application/json' })
     end
 
-    it "requires an error when args missing" do
+    it "raises an error when args missing" do
       expect { zc.revoke_tokens }.to raise_error(Zoom::ParameterMissing, [:token].to_s)
     end
 

--- a/spec/lib/zoom/actions/token/revoke_token_spec.rb
+++ b/spec/lib/zoom/actions/token/revoke_token_spec.rb
@@ -7,12 +7,27 @@ describe Zoom::Actions::Token do
   let(:args) { { access_token: 'xxx' } }
 
   describe '#revoke_tokens action' do
+    let(:path) { '/oauth/revoke' }
+
+    let(:params) do
+      {
+        base_uri: "https://zoom.us/",
+        body: '{"token":"xxx"}',
+        headers: {
+          "Accept" => "application/json",
+          "Authorization" => "Bearer ",
+          "Content-Type" => "application/x-www-form-urlencoded"
+        }
+      }
+    end
+
     before :each do
-      stub_request(
-        :post,
-        zoom_auth_url('oauth/revoke')
-      ).to_return(body: json_response('token', 'revoke_token'),
-                    headers: { 'Content-Type' => 'application/json' })
+      allow(Zoom::Utils).to receive(:parse_response).and_return(code: 200)
+      allow(Zoom::Client::OAuth).to(
+        receive(:post).with(path, params)
+          .and_return(body: json_response('token', 'access_token'),
+                        headers: { 'Content-Type' => 'application/json' })
+      )
     end
 
     it "raises an error when args missing" do
@@ -21,6 +36,11 @@ describe Zoom::Actions::Token do
 
     it 'returns a hash' do
       expect(zc.revoke_tokens(args)).to be_kind_of(Hash)
+    end
+
+    it 'passes args in the body and sends x-www-form-urlencoded header' do
+      zc.revoke_tokens(args)
+      expect(Zoom::Client::OAuth).to have_received(:post).with(path, params)
     end
   end
 end

--- a/spec/lib/zoom/actions_spec.rb
+++ b/spec/lib/zoom/actions_spec.rb
@@ -12,7 +12,7 @@ describe Zoom::Actions do
 
   describe 'self.extract_path_keys' do
     subject { described_class.extract_path_keys(path) }
-    
+
     it { is_expected.to match_array(path_keys) }
   end
 
@@ -23,7 +23,12 @@ describe Zoom::Actions do
   end
 
   describe 'self.make_request' do
-    subject { described_class.make_request(client, method, parsed_path, params, base_uri) }
+    subject do
+      described_class.make_request({
+        client: client, method: method, parsed_path: parsed_path,
+        params: params, base_uri: base_uri
+      })
+    end
 
     let(:request_options) {
       {


### PR DESCRIPTION
This addresses https://github.com/hintmedia/zoom_rb/issues/401 .

Our internal KUDO identifier is KMP-1946 .

Zoom has announced some security improvements to their API. On May 15th, 2022, their API will require that parameters in requests for access tokens, refresh tokens, and revoking tokens are included in the body of the POST instead of as URL parameters. This gem needs to be updated so that tokens and codes are part of the POST body instead of URL parameters for the access_tokens, refresh_tokens, and revoke_tokens calls.

This PR updates access_tokens, refresh_tokens, and revoke_tokens actions.