### PR TITLE
KMP-1953 Support for PKCE

### DIFF
--- a/lib/zoom/actions/token.rb
+++ b/lib/zoom/actions/token.rb
@@ -9,6 +9,7 @@ module Zoom
         '/oauth/token',
         oauth: true,
         require: %i[grant_type code redirect_uri],
+        permit: :code_verifier,
         args_to_params: { auth_code: :code }
 
       post 'refresh_tokens',

--- a/lib/zoom/clients/oauth.rb
+++ b/lib/zoom/clients/oauth.rb
@@ -13,7 +13,7 @@ module Zoom
       # Returns (access_token, refresh_token)
       #
       def initialize(config)
-        Zoom::Params.new(config).permit( %i[auth_token auth_code redirect_uri access_token refresh_token timeout])
+        Zoom::Params.new(config).permit( %i[auth_token auth_code redirect_uri access_token refresh_token timeout code_verifier])
         Zoom::Params.new(config).require_one_of(%i[access_token refresh_token auth_code])
         if (config.keys & [:auth_code, :redirect_uri]).any?
           Zoom::Params.new(config).require( %i[auth_code redirect_uri])

--- a/spec/lib/zoom/actions/token/access_token_spec.rb
+++ b/spec/lib/zoom/actions/token/access_token_spec.rb
@@ -4,8 +4,8 @@ require 'spec_helper'
 
 describe Zoom::Actions::Token do
   let(:zc) { oauth_client }
-  let(:args) { { grant_type: 'authorization_code', auth_code: 'xxx', redirect_uri: 'http://localhost:3000' } }
-  let(:body) { { grant_type: 'authorization_code', redirect_uri: 'http://localhost:3000', code: 'xxx' } }
+  let(:args) { { grant_type: 'authorization_code', auth_code: 'xxx', redirect_uri: 'http://localhost:3000', code_verifier: 'xxx' } }
+  let(:body) { { grant_type: 'authorization_code', redirect_uri: 'http://localhost:3000', code_verifier: 'xxx', code: 'xxx'  } }
 
   describe '#access_tokens action' do
     let(:path) { '/oauth/token' }


### PR DESCRIPTION
KMP-1953

This PR adds support for the code_verifier parameter which is required if using PKCE. A cryptographically random string used to correlate the authorization request to the token request.

How to use PKCE with Zoom API is described here: https://marketplace.zoom.us/docs/guides/auth/oauth