### PR TITLE
KMP-3014: Enhanced error generation

### DIFF
--- a/lib/zoom/error.rb
+++ b/lib/zoom/error.rb
@@ -15,4 +15,11 @@ module Zoom
   class ParameterNotPermitted < StandardError; end
   class ParameterValueNotPermitted < StandardError; end
   class AuthenticationError < StandardError; end
+  class BadRequest < StandardError; end
+  class Unauthorized < StandardError; end
+  class Forbidden < StandardError; end
+  class NotFound < StandardError; end
+  class Conflict < StandardError; end
+  class TooManyRequests < StandardError; end
+  class InternalServerError < StandardError; end
 end

--- a/lib/zoom/utils.rb
+++ b/lib/zoom/utils.rb
@@ -22,7 +22,8 @@ module Zoom
         raise Unauthorized, error_hash if code == 401
         raise Forbidden, error_hash if code == 403
         raise NotFound, error_hash if code == 404
-        raise Conflict, error_hash if code == 429
+        raise Conflict, error_hash if code == 409
+        raise TooManyRequests, error_hash if code == 429
         raise InternalServerError, error_hash if code == 500
         raise Error.new(error_hash, error_hash)
       end

--- a/lib/zoom/utils.rb
+++ b/lib/zoom/utils.rb
@@ -15,10 +15,16 @@ module Zoom
         return response unless response.is_a?(Hash) && response.key?('code')
 
         code = response['code']
-
-        raise AuthenticationError, build_error(response) if code == 124
         error_hash = build_error(response)
-        raise Error.new(error_hash, error_hash) if code >= 300 || http_code >= 400
+
+        raise AuthenticationError, error_hash if code == 124
+        raise BadRequest, error_hash if code == 400
+        raise Unauthorized, error_hash if code == 401
+        raise Forbidden, error_hash if code == 403
+        raise NotFound, error_hash if code == 404
+        raise Conflict, error_hash if code == 429
+        raise InternalServerError, error_hash if code == 500
+        raise Error.new(error_hash, error_hash)
       end
 
       def build_error(response)

--- a/spec/lib/zoom/actions/groups/create_spec.rb
+++ b/spec/lib/zoom/actions/groups/create_spec.rb
@@ -59,7 +59,7 @@ describe Zoom::Actions::Groups do
       end
 
       it 'raises an error' do
-        expect { response }.to raise_error(Zoom::Error)
+        expect { response }.to raise_error(Zoom::Conflict)
       end
     end
 

--- a/spec/lib/zoom/actions/groups/create_spec.rb
+++ b/spec/lib/zoom/actions/groups/create_spec.rb
@@ -44,7 +44,7 @@ describe Zoom::Actions::Groups do
       end
 
       it 'raises an error' do
-        expect { response }.to raise_error(Zoom::Error)
+        expect { response }.to raise_error(Zoom::Conflict)
       end
     end
 
@@ -59,7 +59,7 @@ describe Zoom::Actions::Groups do
       end
 
       it 'raises an error' do
-        expect { response }.to raise_error(Zoom::Conflict)
+        expect { response }.to raise_error(Zoom::TooManyRequests)
       end
     end
 

--- a/spec/lib/zoom/actions/groups/update_spec.rb
+++ b/spec/lib/zoom/actions/groups/update_spec.rb
@@ -32,12 +32,12 @@ describe Zoom::Actions::Groups do
           :patch,
           zoom_url("/groups/#{args[:group_id]}")
         ).to_return(status: 404,
-                    body: json_response('error', 'group_not_exist'),
+                    body: '{ "code": 404, "message": "Group name Zoom Group Name is already in use." }',
                     headers: { 'Content-Type' => 'application/json' })
       end
 
-      it 'raises an error' do
-        expect { zc.group_update(args) }.to raise_error(Zoom::Error)
+      it 'raises Zoom::NotFound' do
+        expect { zc.group_update(args) }.to raise_error(Zoom::NotFound)
       end
     end
 
@@ -51,8 +51,8 @@ describe Zoom::Actions::Groups do
                     headers: { 'Content-Type' => 'application/json' })
       end
 
-      it 'raises an error' do
-        expect { zc.group_update(args) }.to raise_error(Zoom::Error)
+      it 'raises Zoom::Conflict' do
+        expect { zc.group_update(args) }.to raise_error(Zoom::Conflict)
       end
     end
   end

--- a/spec/lib/zoom/actions/im/chat/channels/get_spec.rb
+++ b/spec/lib/zoom/actions/im/chat/channels/get_spec.rb
@@ -38,7 +38,7 @@ describe Zoom::Actions::IM::Chat do
       end
 
       it 'raises Zoom::Error exception' do
-        expect { zc.get_chat_channels(args) }.to raise_error(Zoom::Error, {
+        expect { zc.get_chat_channels(args) }.to raise_error(Zoom::BadRequest, {
           base: "Unauthorized request. You do not have permission to access this user’s channel information."
         }.to_s)
       end

--- a/spec/lib/zoom/actions/user/update_email_spec.rb
+++ b/spec/lib/zoom/actions/user/update_email_spec.rb
@@ -37,7 +37,7 @@ describe Zoom::Actions::User do
       end
 
       it 'raises an error' do
-        expect { zc.user_email_update(args) }.to raise_error(Zoom::Error)
+        expect { zc.user_email_update(args) }.to raise_error(Zoom::BadRequest)
       end
     end
 

--- a/spec/lib/zoom/actions/user/update_status_spec.rb
+++ b/spec/lib/zoom/actions/user/update_status_spec.rb
@@ -37,7 +37,7 @@ describe Zoom::Actions::User do
       end
 
       it 'raises an error' do
-        expect { zc.user_status_update(args) }.to raise_error(Zoom::Error)
+        expect { zc.user_status_update(args) }.to raise_error(Zoom::BadRequest)
       end
     end
 

--- a/spec/lib/zoom/utils_spec.rb
+++ b/spec/lib/zoom/utils_spec.rb
@@ -16,37 +16,42 @@ describe Zoom::Utils do
 
   describe '#raise_if_error!' do
     it 'raises Zoom::AuthenticationError if error is present and code = 124' do
-      response = { 'code' => 124, 'message' => 'Invalid access token.' }
+      response = { 'code' => 124, 'message' => 'Authentication error.' }
       expect { Utils.raise_if_error!(response) }.to raise_error(Zoom::AuthenticationError)
     end
 
     it 'raises Zoom::BadRequest if error is present and code = 400' do
-      response = { 'code' => 400, 'message' => 'Invalid access token.' }
+      response = { 'code' => 400, 'message' => 'Bas request.' }
       expect { Utils.raise_if_error!(response) }.to raise_error(Zoom::BadRequest)
     end
 
     it 'raises Zoom::Unauthorized if error is present and code = 401' do
-      response = { 'code' => 401, 'message' => 'Invalid access token.' }
+      response = { 'code' => 401, 'message' => 'Unauthorized.' }
       expect { Utils.raise_if_error!(response) }.to raise_error(Zoom::Unauthorized)
     end
 
     it 'raises Zoom::Forbidden if error is present and code = 403' do
-      response = { 'code' => 403, 'message' => 'Invalid access token.' }
+      response = { 'code' => 403, 'message' => 'Forbidden.' }
       expect { Utils.raise_if_error!(response) }.to raise_error(Zoom::Forbidden)
     end
 
     it 'raises Zoom::NotFound if error is present and code = 404' do
-      response = { 'code' => 404, 'message' => 'Invalid access token.' }
+      response = { 'code' => 404, 'message' => 'NotFound.' }
       expect { Utils.raise_if_error!(response) }.to raise_error(Zoom::NotFound)
     end
 
-    it 'raises Zoom::Conflict if error is present and code = 429' do
-      response = { 'code' => 429, 'message' => 'Invalid access token.' }
+    it 'raises Zoom::Conflict if error is present and code = 409' do
+      response = { 'code' => 409, 'message' => 'Conflict.' }
       expect { Utils.raise_if_error!(response) }.to raise_error(Zoom::Conflict)
     end
 
+    it 'raises Zoom::TooManyRequests if error is present and code = 429' do
+      response = { 'code' => 429, 'message' => 'Too many requests.' }
+      expect { Utils.raise_if_error!(response) }.to raise_error(Zoom::TooManyRequests)
+    end
+
     it 'raises Zoom::InternalServerError if error is present and code = 500' do
-      response = { 'code' => 500, 'message' => 'Invalid access token.' }
+      response = { 'code' => 500, 'message' => 'Internal server error.' }
       expect { Utils.raise_if_error!(response) }.to raise_error(Zoom::InternalServerError)
     end
 

--- a/spec/lib/zoom/utils_spec.rb
+++ b/spec/lib/zoom/utils_spec.rb
@@ -20,9 +20,34 @@ describe Zoom::Utils do
       expect { Utils.raise_if_error!(response) }.to raise_error(Zoom::AuthenticationError)
     end
 
-    it 'raises Zoom::Error if error is present and code >= 300' do
-      response = { 'code' => 400, 'message' => 'lol error' }
-      expect { Utils.raise_if_error!(response) }.to raise_error(Zoom::Error)
+    it 'raises Zoom::BadRequest if error is present and code = 400' do
+      response = { 'code' => 400, 'message' => 'Invalid access token.' }
+      expect { Utils.raise_if_error!(response) }.to raise_error(Zoom::BadRequest)
+    end
+
+    it 'raises Zoom::Unauthorized if error is present and code = 401' do
+      response = { 'code' => 401, 'message' => 'Invalid access token.' }
+      expect { Utils.raise_if_error!(response) }.to raise_error(Zoom::Unauthorized)
+    end
+
+    it 'raises Zoom::Forbidden if error is present and code = 403' do
+      response = { 'code' => 403, 'message' => 'Invalid access token.' }
+      expect { Utils.raise_if_error!(response) }.to raise_error(Zoom::Forbidden)
+    end
+
+    it 'raises Zoom::NotFound if error is present and code = 404' do
+      response = { 'code' => 404, 'message' => 'Invalid access token.' }
+      expect { Utils.raise_if_error!(response) }.to raise_error(Zoom::NotFound)
+    end
+
+    it 'raises Zoom::Conflict if error is present and code = 429' do
+      response = { 'code' => 429, 'message' => 'Invalid access token.' }
+      expect { Utils.raise_if_error!(response) }.to raise_error(Zoom::Conflict)
+    end
+
+    it 'raises Zoom::InternalServerError if error is present and code = 500' do
+      response = { 'code' => 500, 'message' => 'Invalid access token.' }
+      expect { Utils.raise_if_error!(response) }.to raise_error(Zoom::InternalServerError)
     end
 
     it 'does not raise Zoom::Error if error is not present' do
@@ -35,11 +60,10 @@ describe Zoom::Utils do
       expect { Utils.raise_if_error!(response) }.to_not raise_error
     end
 
-    it 'raises Zoom::Error if http code is not 200' do
+    it 'raises Zoom::Error if http code is not in [124, 400, 401, 403, 404, 429, 500]' do
       response = { 'code' => 180, 'message' => 'lol error' }
       expect { Utils.raise_if_error!(response, 400) }.to raise_error(Zoom::Error)
     end
-
   end
 
   describe '#extract_options!' do


### PR DESCRIPTION
KMP-3014

It's hard to handle errors generated by the gem in the App which uses it because the errors are too common. There is only Zoom::AuthenticationError and Zoom::Error for any other cases.

This PR improves error generation. The error classes added for common http codes.
https://marketplace.zoom.us/docs/api-reference/error-definitions is used for reference.