### PR TITLE
KMP-3408: Query params for delete

### DIFF
--- a/lib/zoom/actions.rb
+++ b/lib/zoom/actions.rb
@@ -30,7 +30,7 @@ module Zoom
       client, method, parsed_path, params, request_options, oauth =
         args.values_at :client, :method, :parsed_path, :params, :request_options, :oauth
       case method
-      when :get
+      when :get, :delete
         request_options[:query] = params
       when :post, :put, :patch
         request_options[:body] =

--- a/spec/lib/zoom/actions_spec.rb
+++ b/spec/lib/zoom/actions_spec.rb
@@ -83,6 +83,7 @@ describe Zoom::Actions do
       let(:method) { :delete }
 
       it 'calls delete method on client with delete request_options' do
+        request_options[:query] = params
         expect(client.class).to receive(method).with(parsed_path, **request_options)
         subject
       end


### PR DESCRIPTION
KMP-3408

Now by default extra parameters for DELETE requests are not passed. This PR changes it to pass params in the query string.