### PR TITLE
KMP-3446: next_page_token parameter for webinar_list request

### DIFF
--- a/lib/zoom/actions/webinar.rb
+++ b/lib/zoom/actions/webinar.rb
@@ -32,7 +32,7 @@ module Zoom
                       ].freeze
 
       get 'webinar_list', '/users/:host_id/webinars',
-        permit: %i[page_size page_number]
+        permit: %i[page_size next_page_token]
 
       # TODO: process recurrence keys based on constants
       # TODO: process settings keys based on constants


### PR DESCRIPTION
KMP-3446

https://marketplace.zoom.us/docs/api-reference/zoom-api/methods/#tag/Webinars/operation/webinars

To get all User's webinars from Zoom API we need to fetch all the pages. `page_number` parameter is deprecated, new one is `next_page_token`.

This PR removes `page_number` from `webinar_list` requests's permitted parameters and adds `next_page_token`.